### PR TITLE
Path fix : full path not needed

### DIFF
--- a/sds.sh
+++ b/sds.sh
@@ -14,7 +14,7 @@ gpio -g mode 22 out
 gpio -g write 22 1
 
 while [ 1 ]; do
-  if [ "$(/home/pi/wiringPi/gpio/gpio -g read 17)" = "1" ]; then
+  if [ "$(gpio -g read 17)" = "1" ]; then
         echo "ShutDown order received, RaspBerry pi will now enter in standby mode..."
         sudo shutdown -h -P now
         break

--- a/softshutdown.sh
+++ b/softshutdown.sh
@@ -8,7 +8,7 @@ PATH=/usr/bin:/home/pi/wiringPi/gpio
 echo "Setting pin GPIO4 High"
 gpio mode 7 out
 gpio write 7 1
-sleep 1
+/bin/sleep 1
 echo "Setting pin GPIO4 Low"
 gpio write 7 0
 


### PR DESCRIPTION
Fix a path in the `sds.sh` script. If the beginning of the script works correctly (calls to `gpio`) then the full path is not needed in the `if`.